### PR TITLE
Allow to relay cookies in OAuth process.

### DIFF
--- a/oauthproxy_test.go
+++ b/oauthproxy_test.go
@@ -421,7 +421,7 @@ func Test_redeemCode(t *testing.T) {
 	}
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
-	_, err = proxy.redeemCode(req)
+	_, err = proxy.redeemCode(req.Context(), req)
 	assert.Equal(t, providers.ErrMissingCode, err)
 }
 

--- a/pkg/apis/options/cookie.go
+++ b/pkg/apis/options/cookie.go
@@ -17,6 +17,7 @@ type Cookie struct {
 	Secure   bool          `flag:"cookie-secure" cfg:"cookie_secure"`
 	HTTPOnly bool          `flag:"cookie-httponly" cfg:"cookie_httponly"`
 	SameSite string        `flag:"cookie-samesite" cfg:"cookie_samesite"`
+	Relay    []string      `flag:"cookie-relay" cfg:"cookie_relay"`
 }
 
 func cookieFlagSet() *pflag.FlagSet {
@@ -31,6 +32,7 @@ func cookieFlagSet() *pflag.FlagSet {
 	flagSet.Bool("cookie-secure", true, "set secure (HTTPS) cookie flag")
 	flagSet.Bool("cookie-httponly", true, "set HttpOnly cookie flag")
 	flagSet.String("cookie-samesite", "", "set SameSite cookie attribute (ie: \"lax\", \"strict\", \"none\", or \"\"). ")
+	flagSet.StringSlice("cookie-relay", []string{}, "Optional cookies to relay from front to back. Can be used for LB sticky sessions.")
 
 	return flagSet
 }
@@ -47,5 +49,6 @@ func cookieDefaults() Cookie {
 		Secure:   true,
 		HTTPOnly: true,
 		SameSite: "",
+		Relay:    nil,
 	}
 }

--- a/providers/criteo.go
+++ b/providers/criteo.go
@@ -106,11 +106,12 @@ func (p *CriteoProvider) GetProfile(ctx context.Context, s *sessions.SessionStat
 	}
 
 	var info tokenInfo
-	err := requests.New(p.ProfileURL.String()).
+	req := requests.New(p.ProfileURL.String()).
 		WithContext(ctx).
-		WithHeaders(getCriteoHeader(s.AccessToken)).
-		Do().
-		UnmarshalInto(&info)
+		WithHeaders(getCriteoHeader(s.AccessToken))
+
+	// Adding cookies if required before executing the request
+	err := EnrichRequestWithCookies(ctx, req).Do().UnmarshalInto(&info)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This will allow to go through processing by specifying optional load
balancer related sticky cookies.

## Description

When Oauth is happening, check if some known cookies must be sent to backend when redeeming token & grabbing user information. This can help load balancers to target the correct instance, or send mandatory cookies on some oauth implementations.
